### PR TITLE
Add a route in the server that will allow the HUB to retrieve the current configuration of the agent

### DIFF
--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -4,35 +4,35 @@ use std::env::var as env_var;
 use std::path::{Path, PathBuf};
 use tracing::info;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct AgentData {
     pub latest_version: String,
     pub minimal_version: String,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct FileListerConfig {
     pub dir: Vec<PathBuf>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct FileWatcherConfig {
     pub dir: Vec<PathBuf>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ServerConfig {
     pub address: String,
     pub log_level: String,
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct HttpConfig {
     pub host: String,
     pub auth_path: String,
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct HubConfig {
     pub host: String,
     pub port: String,
@@ -42,7 +42,7 @@ pub struct HubConfig {
     pub connection_attempt_limit: u32,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Clone, Deserialize)]
 pub struct LoggerConfig {
     pub term_level: String,
     pub file_level: String,
@@ -54,7 +54,7 @@ pub struct MyFilesConfiguration {
     pub drop_db_on_start: bool,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone, Serialize)]
 pub struct Configuration {
     pub agent_data: AgentData,
     pub file_lister_config: FileListerConfig,

--- a/src/http/routes.rs
+++ b/src/http/routes.rs
@@ -17,10 +17,22 @@ pub struct MyFilesState {
     pub my_files: Arc<Mutex<my_files::MyFiles>>,
 }
 
+#[derive(Clone)]
+pub struct GlobalConfigState {
+    pub config: crate::configuration::Configuration,
+    pub rules: Vec<crate::tidy_algo::TidyRule>,
+}
+
 #[derive(Deserialize)]
 pub struct GetFilesParams {
     amount: usize,
     sort_by: String,
+}
+
+
+#[derive(Deserialize)]
+pub struct GetConfigParams {
+    rules: bool
 }
 
 #[derive(Serialize)]
@@ -63,4 +75,25 @@ pub async fn get_files(
     });
     let result = files_vec.into_iter().take(query_params.amount).collect();
     Json(result)
+}
+
+#[derive(Serialize)]
+pub struct GetConfigResponseType {
+    configuration: crate::configuration::Configuration,
+    rules: Option<Vec<crate::tidy_algo::TidyRule>>,
+}
+
+pub async fn get_config(State(global_config): State<GlobalConfigState>, Query(query_params): Query<GetConfigParams>) -> Json<GetConfigResponseType> {
+    let configuration = global_config.config;
+    let rules = global_config.rules;
+    let mut response = GetConfigResponseType {
+        configuration,
+        rules: None
+    };
+
+    if query_params.rules {
+        response.rules = Some(rules);
+    }
+
+    Json(response)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@ pub async fn run() {
     };
 
     let my_files_builder = my_files::MyFilesBuilder::new()
-        .configure(config.my_files_config)
+        .configure(config.clone().my_files_config.clone())
         .seal();
 
     let my_files: my_files::MyFiles = my_files_builder.build().unwrap();
@@ -74,11 +74,13 @@ pub async fn run() {
         Err(err) => error!("Failed to load rules into TidyAlgo from config/rules/basic.yml: {err}"),
     };
 
-    list_directories(config.file_lister_config.dir, &my_files, &tidy_algo);
+    list_directories(config.clone().file_lister_config.dir, &my_files, &tidy_algo);
     update_all_grades(&my_files, &tidy_algo);
 
     let server = ServerBuilder::new()
         .my_files_builder(my_files_builder)
+        .inject_global_configuration(config.clone())
+        .inject_tidy_rules(tidy_algo.clone())
         .build(
             config.agent_data.latest_version.clone(),
             config.agent_data.minimal_version.clone(),

--- a/src/tidy_algo.rs
+++ b/src/tidy_algo.rs
@@ -4,6 +4,7 @@ use crate::tidy_rules::duplicated;
 use crate::tidy_rules::misnamed;
 use crate::tidy_rules::perished;
 use config::{Config, ConfigError, File, Value};
+use serde::Serialize;
 use std::collections::HashMap;
 use std::error::Error;
 use std::path::{self, PathBuf};
@@ -11,13 +12,15 @@ use tracing::debug;
 
 /// Represents a rule that can be applied to a file
 #[allow(dead_code)]
-#[derive(Debug)]
+#[derive(Debug, Serialize, Clone)]
 pub struct TidyRule {
     name: String,
     log: String,
     scope: String,
     weight: u64,
+    #[serde(skip_serializing, skip_deserializing)]
     pub params: HashMap<String, Value>,
+    #[serde(skip_serializing, skip_deserializing)]
     apply: fn(&FileInfo, &MyFiles, HashMap<String, Value>) -> TidyScore,
 }
 
@@ -67,6 +70,7 @@ impl TidyGrade {
     }
 }
 
+#[derive(Clone)]
 pub struct TidyAlgo {
     rules: Vec<TidyRule>,
 }
@@ -134,6 +138,10 @@ impl TidyAlgo {
             let _ = self.load_rule_from_hashmap(table);
         }
         Ok(self.rules.len())
+    }
+
+    pub fn get_rules(&self) -> &Vec<TidyRule> {
+        &self.rules
     }
 
     /// Apply the rules to a file


### PR DESCRIPTION
The route is `GET /config?rules=<true|false>` with a required query parameter to include the rules or not

Close #138 

<details>

<summary>example query response</summary>

```bash
~
❯ curl localhost:8111/config?rules=true |ConvertFrom-Json |ConvertTo-Json
```
```json
{
  "configuration": {
    "agent_data": {
      "latest_version": "0.1.0",
      "minimal_version": "0.1.0"
    },
    "file_lister_config": {
      "dir": "tests/assets/test_folder"
    },
    "file_watcher_config": {
      "dir": "tests/assets/test_folder"
    },
    "server_config": {
      "address": "0.0.0.0:8111",
      "log_level": "info"
    },
    "logger_config": {
      "term_level": "debug",
      "file_level": "warn"
    },
    "my_files_config": {
      "db_path": "./my_files.db",
      "drop_db_on_start": true
    },
    "hub_config": {
      "host": "localhost",
      "port": "7001",
      "protocol": "http",
      "auth_path": "/gateway/auth/AOTH",
      "disconnect_path": "/gateway/auth/AOTH/{agent_id}/disconnect",
      "connection_attempt_limit": 30
    }
  },
  "rules": [
    {
      "name": "Rule 1",
      "log": "warn",
      "scope": "tests/assets/test_folder",
      "weight": 1
    },
    {
      "name": "Rule 2",
      "log": "log",
      "scope": "tests/assets/test_folder",
      "weight": 2
    },
    {
      "name": "Rule 3",
      "log": "alert",
      "scope": "tests/assets/test_folder",
      "weight": 3
    }
  ]
}
``` 

</details>
