### PR TITLE
Build and push an container image to the repository container registry

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,0 +1,48 @@
+name: Build and push tidybee-agent image to ghcr.io
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: tiydbee-agent
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Fetch metadata
+        id: metadata
+        uses: docker/metadata-action@v5
+        with:
+          images: tidybee/tidybee-agent
+
+      - name: Login to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ steps.metadata.outputs.tags }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -43,6 +43,6 @@ jobs:
         with:
           context: .
           push: true
-          tags: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ steps.metadata.outputs.tags }}
+          tags: ${{ env.REGISTRY }}/${{ steps.metadata.outputs.tags }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ COPY --from=cacher /usr/local/cargo /usr/local/cargo
 RUN cargo build --release
 
 FROM gcr.io/distroless/cc-debian11
+LABEL org.opencontainers.image.source=https://github.com/TidyBee/tidybee-agent-deployment
 WORKDIR /app
 COPY --from=builder /app/config /app/config
 COPY --from=builder /app/tests/assets /app/tests/assets

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ COPY --from=cacher /usr/local/cargo /usr/local/cargo
 RUN cargo build --release
 
 FROM gcr.io/distroless/cc-debian11
-LABEL org.opencontainers.image.source=https://github.com/TidyBee/tidybee-agent-deployment
+LABEL org.opencontainers.image.source=https://github.com/TidyBee/tidybee-agent
 WORKDIR /app
 COPY --from=builder /app/config /app/config
 COPY --from=builder /app/tests/assets /app/tests/assets


### PR DESCRIPTION
Adds the `tidybee-agent`  docker image to the repository for a better deployment.
Actions logs example can be found here: [https://github.com/TidyBee/tidybee-agent-deployment/actions/runs/8358884864](https://github.com/TidyBee/tidybee-agent-deployment/actions/runs/8358884864)

The generated image can be found [here](https://github.com/orgs/TidyBee/packages?repo_name=tidybee-agent-deployment) (see screen);
![image](https://github.com/TidyBee/tidybee-agent/assets/38893947/54abd32d-5621-4863-a2b1-17941f9d9dde)
